### PR TITLE
Allow delay to be set in the function

### DIFF
--- a/firmware/IRTransmitter.cpp
+++ b/firmware/IRTransmitter.cpp
@@ -7,7 +7,7 @@ const int IRTransmitter::period = (1000000 + carrier_frequency / 2) / carrier_fr
 const int IRTransmitter::high_time = period * duty_cycle / 100;
 const int IRTransmitter::low_time = period - high_time;
 
-IRTransmitter::IRTransmitter(uint8_t ir_output_pin, uint8_t led_pin {
+IRTransmitter::IRTransmitter(uint8_t ir_output_pin, uint8_t led_pin) {
     ir_output_pin_ = ir_output_pin;
     led_pin_ = led_pin;
 

--- a/firmware/IRTransmitter.cpp
+++ b/firmware/IRTransmitter.cpp
@@ -7,7 +7,7 @@ const int IRTransmitter::period = (1000000 + carrier_frequency / 2) / carrier_fr
 const int IRTransmitter::high_time = period * duty_cycle / 100;
 const int IRTransmitter::low_time = period - high_time;
 
-IRTransmitter::IRTransmitter(unsigned int ir_output_pin, unsigned int led_pin) {
+IRTransmitter::IRTransmitter(uint8_t ir_output_pin, uint8_t led_pin {
     ir_output_pin_ = ir_output_pin;
     led_pin_ = led_pin;
 
@@ -39,7 +39,7 @@ void IRTransmitter::Space(unsigned int sLen) {
     while ((micros() - now) < dur); // just wait here until time is up
 }
 
-void IRTransmitter::Transmit(unsigned int *data, size_t length) {
+void IRTransmitter::Transmit(unsigned int *data, size_t length, uint32_t wait) {
     // First send the NEC RAW signal
     digitalWrite(led_pin_, HIGH);
     sig_time_ = micros(); // keeps rolling track of signal time to avoid impact of loop & code execution delays
@@ -48,5 +48,5 @@ void IRTransmitter::Transmit(unsigned int *data, size_t length) {
         if (i < length) Space(data[i]); // pointer will be moved by for loop
     }
     digitalWrite(led_pin_, LOW);
-    delay(500);
+    delay(wait);
 }

--- a/firmware/IRTransmitter.h
+++ b/firmware/IRTransmitter.h
@@ -1,3 +1,4 @@
+
 #ifndef IRTransmitter_h
 #define IRTransmitter_h
 
@@ -6,8 +7,8 @@
 class IRTransmitter
 {
     public:
-        IRTransmitter(unsigned int ir_output_pin, unsigned int led_pin);
-        void Transmit(unsigned int *data, size_t length);
+        IRTransmitter(uint8_t ir_output_pin, uint8_t led_pin);
+        void Transmit(unsigned int *data, size_t length, uint32_t wait = 5000);
 
     private:
         int ir_output_pin_;

--- a/spark.json
+++ b/spark.json
@@ -1,6 +1,6 @@
 {
   "name": "IRTransmitter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "AnalysIR",
   "license": "",
   "description": "Simple IR Transmitter library for the Particle Photon. Full credit goes to: AnalysIR (https://www.analysir.com/blog/2015/09/01/simple-infrared-pwm-on-arduino-part-3-hex-ir-signals/)"


### PR DESCRIPTION
This commit allows a delay to be set by the user without modifying the library. For example this would set the delay to 200:
`transmitter.Transmit(rawData[1], sizeof(rawData[1]) / sizeof(rawData[1][0]),200);` 

If the delay parameter is left off it will default to 5000 as previously . 
